### PR TITLE
Fix planet rendering and core settings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1303,6 +1303,11 @@ const shareKeys = [
   "colorLow",
   "colorMid",
   "colorHigh",
+  // Palette/core additions
+  "colorCore",
+  "coreEnabled",
+  "coreSize",
+  "coreVisible",
   "atmosphereColor",
   "cloudsOpacity",
   "cloudHeight",
@@ -2519,7 +2524,8 @@ function sampleColor(elevation, radius) {
   }
 
   // No core color blending - using physical core sphere instead
-  return scratchColor;
+  // Apply the sampled baseColor to the shared scratch color and return it
+  return scratchColor.copy(baseColor);
 }
 
 function updatePalette() {
@@ -2550,6 +2556,9 @@ function updateCore() {
 function updateClouds() {
   cloudsMaterial.opacity = params.cloudsOpacity;
   atmosphereMaterial.opacity = THREE.MathUtils.clamp(params.cloudsOpacity * 0.55, 0.05, 0.6);
+  // Toggle visibility based on opacity for reliability
+  cloudsMesh.visible = params.cloudsOpacity > 0.001;
+  atmosphereMesh.visible = params.cloudsOpacity > 0.001;
   // Update cloud layer height/scale
   const cloudScale = Math.max(0.1, params.radius * (1 + Math.max(0, params.cloudHeight || 0.03)));
   cloudsMesh.scale.setScalar(cloudScale);


### PR DESCRIPTION
Restore planet color palette application, re-enable clouds and atmosphere rendering, and make core settings shareable.

The `sampleColor` function was incorrectly returning an uncolored `scratchColor` instead of the palette-derived `baseColor`, leading to dull planet colors. Additionally, clouds and atmosphere meshes were not reliably visible, which is now fixed by explicitly toggling their visibility based on opacity. Core settings are also now included in shareable parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-fdb9f424-95d3-4fd0-922a-e5058abe354c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fdb9f424-95d3-4fd0-922a-e5058abe354c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

