### PR TITLE
Investigate copy share code bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -236,8 +236,39 @@
           copyButton.className = 'recent__action recent__action--ghost';
           copyButton.textContent = 'Copy Code';
           copyButton.addEventListener('click', async () => {
+            async function legacyCopy(text) {
+              return new Promise((resolve, reject) => {
+                const textArea = document.createElement('textarea');
+                textArea.value = text;
+                textArea.setAttribute('readonly', '');
+                textArea.style.position = 'fixed';
+                textArea.style.opacity = '0';
+                textArea.style.left = '0';
+                textArea.style.top = '0';
+                document.body.appendChild(textArea);
+                textArea.focus();
+                textArea.select();
+                try {
+                  const ok = document.execCommand('copy');
+                  document.body.removeChild(textArea);
+                  if (ok) resolve(); else reject(new Error('Copy command failed'));
+                } catch (err) {
+                  document.body.removeChild(textArea);
+                  reject(err);
+                }
+              });
+            }
+
             try {
-              await navigator.clipboard.writeText(item.id);
+              if (navigator.clipboard && window.isSecureContext) {
+                try {
+                  await navigator.clipboard.writeText(item.id);
+                } catch (e) {
+                  await legacyCopy(item.id);
+                }
+              } else {
+                await legacyCopy(item.id);
+              }
               copyButton.textContent = 'Copied!';
               setTimeout(() => {
                 copyButton.textContent = 'Copy Code';

--- a/src/main.js
+++ b/src/main.js
@@ -4300,24 +4300,27 @@ function regenerateCloudTexture() {
 }
 function copyToClipboard(text) {
   if (navigator.clipboard && window.isSecureContext) {
-    return navigator.clipboard.writeText(text);
+    return navigator.clipboard.writeText(text).catch(() => legacyCopyToClipboard(text));
   }
+  return legacyCopyToClipboard(text);
+}
+
+function legacyCopyToClipboard(text) {
   return new Promise((resolve, reject) => {
     const textArea = document.createElement("textarea");
     textArea.value = text;
+    textArea.setAttribute("readonly", "");
     textArea.style.position = "fixed";
     textArea.style.opacity = "0";
+    textArea.style.left = "0";
+    textArea.style.top = "0";
     document.body.appendChild(textArea);
     textArea.focus();
     textArea.select();
     try {
       const ok = document.execCommand("copy");
       document.body.removeChild(textArea);
-      if (ok) {
-        resolve();
-      } else {
-        reject(new Error("Copy command failed"));
-      }
+      if (ok) resolve(); else reject(new Error("Copy command failed"));
     } catch (err) {
       document.body.removeChild(textArea);
       reject(err);


### PR DESCRIPTION
Add robust clipboard copy fallbacks to fix copy/share functionality on mobile and non-secure origins.

The `navigator.clipboard.writeText` API is not available in all contexts (e.g., non-secure HTTP, some mobile browsers). This PR introduces a `legacyCopy` function that uses a temporary textarea and `document.execCommand('copy')` to ensure the copy functionality works reliably across all environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f0bb2b4-78d0-4dd1-9573-a11daa17712c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f0bb2b4-78d0-4dd1-9573-a11daa17712c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

