### PR TITLE
Implement new gas giant planet type

### DIFF
--- a/src/app/gui/planetControls.js
+++ b/src/app/gui/planetControls.js
@@ -670,6 +670,59 @@ export function setupPlanetControls({
       scheduleShareUpdate();
     });
 
+  // Freezing System
+  const freezingFolder = registerFolder(environmentFolder.addFolder("Freezing"), { close: true });
+
+  guiControllers.freezingEnabled = freezingFolder.add(params, "freezingEnabled")
+    .name("Enable Freezing")
+    .onChange(() => {
+      markPlanetDirty();
+      scheduleShareUpdate();
+    });
+
+  guiControllers.iceColor = freezingFolder.addColor(params, "iceColor")
+    .name("Ice Color")
+    .onChange(() => {
+      updatePalette();
+      markPlanetDirty();
+      scheduleShareUpdate();
+    });
+
+  guiControllers.globalTemperature = freezingFolder.add(params, "globalTemperature", -100, 100, 1)
+    .name("Global Temperature (°C)")
+    .onChange(() => {
+      markPlanetDirty();
+      scheduleShareUpdate();
+    });
+
+  guiControllers.freezingThreshold = freezingFolder.add(params, "freezingThreshold", -100, 100, 1)
+    .name("Freezing Threshold (°C)")
+    .onChange(() => {
+      markPlanetDirty();
+      scheduleShareUpdate();
+    });
+
+  guiControllers.iceIntensity = freezingFolder.add(params, "iceIntensity", 0, 2, 0.1)
+    .name("Ice Intensity")
+    .onChange(() => {
+      markPlanetDirty();
+      scheduleShareUpdate();
+    });
+
+  guiControllers.poleFreezeRadius = freezingFolder.add(params, "poleFreezeRadius", 0, 1, 0.05)
+    .name("Pole Freeze Radius")
+    .onChange(() => {
+      markPlanetDirty();
+      scheduleShareUpdate();
+    });
+
+  guiControllers.equatorFreezeRadius = freezingFolder.add(params, "equatorFreezeRadius", 0, 1, 0.05)
+    .name("Equator Freeze Radius")
+    .onChange(() => {
+      markPlanetDirty();
+      scheduleShareUpdate();
+    });
+
   // Rings (overview + global controls; per-ring controls are managed in ringControls.js)
   const ringsFolder = registerFolder(environmentFolder.addFolder("Rings"), { close: true });
 
@@ -793,6 +846,7 @@ export function setupPlanetControls({
     motionFolder,
     environmentFolder,
     sunFolder,
+    freezingFolder,
     ringsFolder,
     spaceFolder,
     effectsFolder

--- a/src/app/gui/planetControls.js
+++ b/src/app/gui/planetControls.js
@@ -182,6 +182,11 @@ export function setupPlanetControls({
           markPlanetDirty();
           scheduleShareUpdate();
         });
+      folder
+        .add(band, "turbulence", 0, 4, 0.01).name("Turbulence").onChange(() => {
+          markPlanetDirty();
+          scheduleShareUpdate();
+        });
       gasStrataFolders.push(folder);
     });
   }
@@ -206,6 +211,24 @@ export function setupPlanetControls({
     });
   guiControllers.gasNoiseStrength = gasFolder.add(params, "gasNoiseStrength", 0, 2, 0.01)
     .name("Noise Strength")
+    .onChange(() => {
+      markPlanetDirty();
+      scheduleShareUpdate();
+    });
+  guiControllers.gasWarpStrength = gasFolder.add(params, "gasWarpStrength", 0, 3, 0.01)
+    .name("Warp Strength")
+    .onChange(() => {
+      markPlanetDirty();
+      scheduleShareUpdate();
+    });
+  guiControllers.gasWarpFrequency = gasFolder.add(params, "gasWarpFrequency", 0.2, 10, 0.05)
+    .name("Warp Frequency")
+    .onChange(() => {
+      markPlanetDirty();
+      scheduleShareUpdate();
+    });
+  guiControllers.gasStreakStrength = gasFolder.add(params, "gasStreakStrength", 0, 3, 0.01)
+    .name("Streak Strength")
     .onChange(() => {
       markPlanetDirty();
       scheduleShareUpdate();

--- a/src/app/gui/planetControls.js
+++ b/src/app/gui/planetControls.js
@@ -143,12 +143,20 @@ export function setupPlanetControls({
   function ensureGasParams() {
     if (!Array.isArray(params.gasStrata)) {
       params.gasStrata = [
-        { color: "#c9b48f", size: 1 },
-        { color: "#a68d6a", size: 1 },
-        { color: "#d8c8a8", size: 1 },
-        { color: "#8a7a5a", size: 1 },
-        { color: "#e6dcc4", size: 1 }
+        { color: "#c9b48f", size: 1, turbulence: 1 },
+        { color: "#a68d6a", size: 1, turbulence: 1 },
+        { color: "#d8c8a8", size: 1, turbulence: 1 },
+        { color: "#8a7a5a", size: 1, turbulence: 1 },
+        { color: "#e6dcc4", size: 1, turbulence: 1 }
       ];
+    }
+    // Ensure existing strata entries have a numeric turbulence field
+    if (Array.isArray(params.gasStrata)) {
+      params.gasStrata = params.gasStrata.map((band) => ({
+        color: band?.color ?? "#c9b48f",
+        size: typeof band?.size === "number" ? band.size : (Number(band?.size) || 1),
+        turbulence: typeof band?.turbulence === "number" ? band.turbulence : 1
+      }));
     }
     if (typeof params.gasStrataCount !== "number") {
       params.gasStrataCount = Math.max(1, params.gasStrata.length);
@@ -158,7 +166,7 @@ export function setupPlanetControls({
   function normalizeGasStrata() {
     ensureGasParams();
     while (params.gasStrata.length < params.gasStrataCount) {
-      params.gasStrata.push({ color: "#c9b48f", size: 1 });
+      params.gasStrata.push({ color: "#c9b48f", size: 1, turbulence: 1 });
     }
     while (params.gasStrata.length > params.gasStrataCount) {
       params.gasStrata.pop();

--- a/src/app/gui/ringControls.js
+++ b/src/app/gui/ringControls.js
@@ -65,6 +65,12 @@ export function setupRingControls({
 
 		normalizeRingSettings();
 		const parent = getRingsFolder?.() || gui;
+		// No folders when there are no rings
+		if (!Array.isArray(params.rings) || params.rings.length === 0) {
+			updateRings?.();
+			applyControlSearch?.({ scrollToFirst: false });
+			return;
+		}
 		params.rings.forEach((ring, index) => {
 			const folder = registerFolder(parent.addFolder(`Ring ${index + 1}`));
 			folder

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 
 export default defineConfig({
   root: ".",
+  base: "./",
   build: {
     outDir: "dist",
     emptyOutDir: true,


### PR DESCRIPTION
Add a 'Gas Giant' planet type with distinct rendering, UI, and collision behavior.

This PR introduces a new 'Gas Giant' planet type, allowing users to create planets with dynamic banded textures, configurable gas strata colors and sizes, and noise effects. Unlike terrestrial planets, gas giants are opaque, lack terrain deformation, oceans, or ice, and their core is always visible. Moon collisions cause gas giants to shrink in radius rather than being destroyed. The UI has been updated to provide specific controls for gas giants and hide irrelevant terrestrial settings. Additionally, real-world planet presets are now grouped under a sub-folder, and the 'Surprise Me' feature can now generate gas giants.

---
<a href="https://cursor.com/background-agent?bcId=bc-100020c8-fb1d-446a-a1f4-32ac81e25e75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-100020c8-fb1d-446a-a1f4-32ac81e25e75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

