### PR TITLE
Add advanced visual settings and performance presets

### DIFF
--- a/src/app/gui/planetControls.js
+++ b/src/app/gui/planetControls.js
@@ -778,7 +778,7 @@ export function setupPlanetControls({
 
   const spaceFolder = registerFolder(environmentFolder.addFolder("Sky"), { close: true });
 
-  guiControllers.starCount = spaceFolder.add(params, "starCount", 500, 4000, 50)
+  guiControllers.starCount = spaceFolder.add(params, "starCount", 0, 4000, 50)
     .name("Star Count")
     .onFinishChange(() => {
       params.starCount = Math.round(params.starCount);

--- a/src/app/stars.js
+++ b/src/app/stars.js
@@ -1,7 +1,8 @@
 import * as THREE from "three";
 
-export function createSunTexture({ inner = 0.1, outer = 1, innerAlpha = 1, outerAlpha = 0 } = {}) {
-  const size = 256;
+export function createSunTexture({ inner = 0.1, outer = 1, innerAlpha = 1, outerAlpha = 0, resolution = 1.0 } = {}) {
+  const scale = Math.max(0.25, Math.min(2.0, resolution || 1.0));
+  const size = Math.max(32, Math.round(256 * scale));
   const canvas = document.createElement("canvas");
   canvas.width = size;
   canvas.height = size;
@@ -18,12 +19,12 @@ export function createSunTexture({ inner = 0.1, outer = 1, innerAlpha = 1, outer
   const texture = new THREE.CanvasTexture(canvas);
   texture.colorSpace = THREE.SRGBColorSpace;
   texture.needsUpdate = true;
-  texture.anisotropy = 2;
+  texture.anisotropy = Math.max(1, Math.round(2 * scale));
   return texture;
 }
 
-export function createStarfield({ seed, count }) {
-  const starCount = Math.max(100, Math.round(count || 2000));
+export function createStarfield({ seed, count, resolution = 1.0 }) {
+  const starCount = Math.max(0, Math.round(count || 2000));
   const geometry = new THREE.BufferGeometry();
   const positions = new Float32Array(starCount * 3);
   const colors = new Float32Array(starCount * 3);
@@ -59,7 +60,7 @@ export function createStarfield({ seed, count }) {
   geometry.setAttribute("aSize", new THREE.BufferAttribute(sizes, 1));
   geometry.setAttribute("aPhase", new THREE.BufferAttribute(phases, 1));
 
-  const pointTexture = createSunTexture({ inner: 0.0, outer: 0.5, innerAlpha: 1, outerAlpha: 0 });
+  const pointTexture = createSunTexture({ inner: 0.0, outer: 0.5, innerAlpha: 1, outerAlpha: 0, resolution });
   const material = new THREE.PointsMaterial({
     size: 1.6,
     map: pointTexture,

--- a/studio.html
+++ b/studio.html
@@ -148,6 +148,17 @@
           </div>
           <div class="visual-settings-body">
             <div class="visual-setting">
+              <label for="visual-settings-preset">Preset:</label>
+              <select id="visual-settings-preset" class="visual-setting-select">
+                <option value="custom">Custom</option>
+                <option value="ultra">Ultra</option>
+                <option value="high">High</option>
+                <option value="default">Default</option>
+                <option value="low">Low</option>
+                <option value="potato">Potato</option>
+              </select>
+            </div>
+            <div class="visual-setting">
               <label for="frame-rate-control">Target Frame Rate:</label>
               <select id="frame-rate-control" class="visual-setting-select">
                 <option value="unlimited">Unlimited</option>
@@ -179,10 +190,31 @@
               </div>
             </div>
             <div class="visual-setting">
+              <label for="star-max">Starfield Max Count:</label>
+              <div class="lighting-scale-container">
+                <input type="range" id="star-max" min="0" max="4000" step="100" value="4000" class="visual-setting-slider">
+                <span id="star-max-value" class="lighting-scale-value">4000</span>
+              </div>
+            </div>
+            <div class="visual-setting">
               <label for="noise-resolution">Noise Resolution:</label>
               <div class="lighting-scale-container">
                 <input type="range" id="noise-resolution" min="0.25" max="2.0" step="0.25" value="1.0" class="visual-setting-slider">
                 <span id="noise-resolution-value" class="lighting-scale-value">100%</span>
+              </div>
+            </div>
+            <div class="visual-setting">
+              <label for="gas-resolution">Gas Giant Resolution:</label>
+              <div class="lighting-scale-container">
+                <input type="range" id="gas-resolution" min="0.25" max="2.0" step="0.25" value="1.0" class="visual-setting-slider">
+                <span id="gas-resolution-value" class="lighting-scale-value">100%</span>
+              </div>
+            </div>
+            <div class="visual-setting">
+              <label for="ring-detail">Ring Detail:</label>
+              <div class="lighting-scale-container">
+                <input type="range" id="ring-detail" min="0.25" max="1.5" step="0.25" value="1.0" class="visual-setting-slider">
+                <span id="ring-detail-value" class="lighting-scale-value">100%</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add visual setting presets plus star, gas and ring performance sliders in the studio popup
- propagate the new settings through the runtime so gas giants, rings, the sun and the starfield all respond to resolution and population limits
- scale gas giant texture generation and starfield assets according to performance settings for better tuning

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ac7b0ee08324915915611d1e19ee