### PR TITLE
Add planet orbit controls and motion simulation

### DIFF
--- a/src/app/gui/planetControls.js
+++ b/src/app/gui/planetControls.js
@@ -19,6 +19,8 @@ export function setupPlanetControls({
   regenerateStarfield,
   updateGravityDisplay,
   initMoonPhysics,
+  onPlanetMotionToggle,
+  onPlanetMotionParamChange,
   getIsApplyingPreset,
   getIsApplyingStarPreset,
   onPresetChange,
@@ -412,6 +414,46 @@ export function setupPlanetControls({
       scheduleShareUpdate();
     });
 
+  const planetPhysicFolder = registerFolder(gui.addFolder("Planet Physic"), { close: true });
+
+  const updatePlanetMotionControllerState = (enabled = params.planetMotionEnabled) => {
+    const method = enabled ? "enable" : "disable";
+    guiControllers.starGravity?.[method]?.();
+    guiControllers.planetForwardSpeed?.[method]?.();
+    guiControllers.planetForwardAngle?.[method]?.();
+  };
+
+  guiControllers.planetMotionEnabled = planetPhysicFolder.add(params, "planetMotionEnabled")
+    .name("Enable Planet Motion")
+    .onChange((value) => {
+      updatePlanetMotionControllerState(value);
+      onPlanetMotionToggle?.(value);
+      scheduleShareUpdate();
+    });
+
+  guiControllers.starGravity = planetPhysicFolder.add(params, "starGravity", 0, 2000, 1)
+    .name("Star Gravity")
+    .onFinishChange(() => {
+      onPlanetMotionParamChange?.({ resetPosition: true });
+      scheduleShareUpdate();
+    });
+
+  guiControllers.planetForwardSpeed = planetPhysicFolder.add(params, "planetForwardSpeed", 0, 10, 0.01)
+    .name("Forward Speed")
+    .onFinishChange(() => {
+      onPlanetMotionParamChange?.({ resetPosition: true });
+      scheduleShareUpdate();
+    });
+
+  guiControllers.planetForwardAngle = planetPhysicFolder.add(params, "planetForwardAngle", -180, 180, 1)
+    .name("Forward Angle")
+    .onFinishChange(() => {
+      onPlanetMotionParamChange?.({ resetPosition: true });
+      scheduleShareUpdate();
+    });
+
+  updatePlanetMotionControllerState();
+
   const environmentFolder = registerFolder(gui.addFolder("Environment"), { close: true });
 
   guiControllers.gravity = environmentFolder.add(params, "gravity", 0.1, 40, 0.1)
@@ -448,6 +490,7 @@ export function setupPlanetControls({
       refreshStarVariantVisibility(value);
       if (shouldSkipStarUpdate()) return;
       updateSun();
+      onPlanetMotionParamChange?.({ resetPosition: true });
       scheduleShareUpdate();
     });
 
@@ -483,6 +526,7 @@ export function setupPlanetControls({
     .onChange(() => {
       if (shouldSkipStarUpdate()) return;
       updateSun();
+      onPlanetMotionParamChange?.({ resetPosition: true });
       scheduleShareUpdate();
     });
 


### PR DESCRIPTION
## Summary
- add a Planet Physic control group with toggles for star gravity, forward speed, and forward angle
- simulate planet motion around the sun using the new settings and keep debug/camera systems in sync
- include the new motion parameters in sharing, presets, and physics initialisation paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d252ec7fec83249e9a90fa954ae5cd