### PR TITLE
Add multi-planet orchestration, system view camera, and management panel

### DIFF
--- a/src/app/planet.js
+++ b/src/app/planet.js
@@ -144,6 +144,9 @@ const PLANET_SURFACE_LOD_ORDER = [
     "lowMed", "microHigh", "micro", "microLow"
 ];
 
+const _sunWorldPosition = new THREE.Vector3();
+const _planetWorldPosition = new THREE.Vector3();
+
 // LOD Transition Manager for smooth transitions
 class LODTransitionManager {
     constructor() {
@@ -637,7 +640,9 @@ export class Planet {
         // Calculate light direction from sun to planet
         const sunDirection = new THREE.Vector3();
         if (this.sun?.sunGroup) {
-            sunDirection.subVectors(this.sun.sunGroup.position, this.planetRoot.position).normalize();
+            this.sun.sunGroup.getWorldPosition(_sunWorldPosition);
+            this.planetRoot.getWorldPosition(_planetWorldPosition);
+            sunDirection.subVectors(_sunWorldPosition, _planetWorldPosition).normalize();
         } else {
             sunDirection.set(1, 0, 0); // Default direction
         }
@@ -1314,7 +1319,13 @@ export class Planet {
         this.atmosphereUniforms.atmosphereRimPower.value = this.params.atmosphereRimPower;
 
         const sunDirection = new THREE.Vector3();
-        sunDirection.subVectors(this.sun.sunGroup.position, this.planetRoot.position).normalize();
+        if (this.sun?.sunGroup) {
+            this.sun.sunGroup.getWorldPosition(_sunWorldPosition);
+            this.planetRoot.getWorldPosition(_planetWorldPosition);
+            sunDirection.subVectors(_sunWorldPosition, _planetWorldPosition).normalize();
+        } else {
+            sunDirection.set(1, 0, 0);
+        }
         this.atmosphereUniforms.lightDirection.value.copy(sunDirection);
 
         this.cloudsMesh.visible = this.params.cloudsOpacity > 0.001;

--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,7 @@ const systemViewCache = {
   position: new THREE.Vector3(),
   target: new THREE.Vector3(),
 };
+const systemStarPosition = new THREE.Vector3();
 let planetSystemApi;
 const clone = (value) => {
   if (typeof structuredClone === "function") {
@@ -255,11 +256,20 @@ function createPlanetSystemApi() {
   return {
     addPlanet: () => {
       if (!planetSystem) return null;
+      const config = createRandomPlanetConfiguration({ allowRingRandomization: true });
       return planetSystem.addPlanet({
         baseState: clone(params),
-        moonSettings: moonSettings.slice(0, params.moonCount).map((moon) => clone(moon)),
+        planetState: config.params,
+        moonSettings: config.moonSettings,
         guiControllers,
         visualSettings,
+        orbitParams: {
+          radius: config.params.radius,
+          spinSpeed: config.params.rotationSpeed,
+          seed: config.params.seed,
+          preset: config.params.preset ?? null,
+          type: config.params.planetType ?? config.params.type ?? "rocky",
+        },
       });
     },
     duplicatePlanet: (id) => {
@@ -272,7 +282,27 @@ function createPlanetSystemApi() {
       if (remaining < 1) return;
       planetSystem.removePlanet(id);
     },
-    regeneratePlanet: (id) => planetSystem?.regeneratePlanet(id, null),
+    regeneratePlanet: (id) => {
+      if (!planetSystem) return;
+      if (id === "primary") {
+        surpriseMe("primary");
+        updateSeedDisplay();
+        updateGravityDisplay();
+        scheduleShareUpdate();
+        return;
+      }
+      const config = createRandomPlanetConfiguration({ allowRingRandomization: true });
+      planetSystem.applyPlanetState(id, config.params, config.moonSettings, {
+        radius: config.params.radius,
+        spinSpeed: config.params.rotationSpeed,
+        seed: config.params.seed,
+        preset: config.params.preset ?? null,
+        type: config.params.planetType ?? config.params.type ?? "rocky",
+      });
+      planetSystem.focusPlanet(id);
+      systemPanel?.setSelected?.(id);
+      scheduleShareUpdate();
+    },
     updatePlanet: (id, patch) => planetSystem?.updatePlanet(id, patch),
     getPlanets: () => planetSystem?.getPlanets() ?? [],
     focusPlanet: (id) => {
@@ -280,6 +310,7 @@ function createPlanetSystemApi() {
       systemViewMode = "close";
       planetSystem.setViewMode("close");
       planetSystem.focusPlanet(id);
+      systemPanel?.setSelected?.(id);
     },
     toggleOrbitGizmos: (visible) => planetSystem?.toggleOrbitGizmos(visible),
     setTimeScale: (scale) => planetSystem?.setTimeScale(scale ?? 1),
@@ -924,7 +955,8 @@ resetAllButton?.addEventListener("click", () => {
 
 surpriseMeButton?.addEventListener("click", () => {
   try {
-    surpriseMe();
+    const targetId = planetSystem?.getCurrentPlanetId?.() ?? "primary";
+    surpriseMe(targetId);
     updateSeedDisplay();
     updateGravityDisplay();
     scheduleShareUpdate();
@@ -1406,7 +1438,10 @@ function animate(timestamp) {
   planetSystem?.update(delta, simulationDelta);
 
   if (planetSystem && systemViewMode === "system") {
-    const frame = computeSystemViewCamera(planetSystem.getPlanets());
+    const frame = computeSystemViewCamera(
+      planetSystem.getPlanets(),
+      planetSystem.getStarWorldPosition(systemStarPosition),
+    );
     camera.position.lerp(frame.position, 0.05);
     controls.target.lerp(frame.target, 0.05);
   }
@@ -1622,7 +1657,8 @@ function setupMobilePanelToggle() {
       mobileMenu?.setAttribute("hidden", "");
       mobileMenuToggle?.setAttribute("aria-expanded", "false");
       try {
-        surpriseMe();
+    const targetId = planetSystem?.getCurrentPlanetId?.() ?? "primary";
+    surpriseMe(targetId);
         updateSeedDisplay();
         updateGravityDisplay();
         scheduleShareUpdate();
@@ -2265,226 +2301,374 @@ function hideLoadingSoon() {
     setTimeout(() => hideLoading(), 30);
 }
   
-function surpriseMe() {
-    const newSeed = generateSeed();
-    const rng = new SeededRNG(newSeed);
-  
-    const isGasGiant = rng.next() < 1 / 6;
-  
-    const prevSimSpeed = params.simulationSpeed;
-    const preserveFoam = params.foamEnabled;
-    const preserveRings = !params.ringAllowRandom;
-    const prevRingSettings = preserveRings
-      ? { ringEnabled: params.ringEnabled, ringAngle: params.ringAngle, ringSpinSpeed: params.ringSpinSpeed, ringCount: params.ringCount, rings: params.rings.map(r => ({...r})) }
-      : null;
-  
-    isApplyingPreset = true;
-    if (isGasGiant) {
-      params.planetType = "gas_giant";
-      const gasGiantPresets = Object.keys(presets).filter(p => presets[p].planetType === 'gas_giant');
-      const pickPreset = gasGiantPresets[Math.floor(rng.next() * gasGiantPresets.length)];
-      applyPreset(pickPreset, { skipShareUpdate: true, keepSeed: true });
-    } else {
-      params.planetType = "rocky";
-      const rockyPresets = Object.keys(presets).filter(p => presets[p].planetType === 'rocky' || !presets[p].planetType);
-      const pickPreset = rockyPresets[Math.floor(rng.next() * rockyPresets.length)];
-      applyPreset(pickPreset, { skipShareUpdate: true, keepSeed: true });
-    }
-    isApplyingPreset = false;
-  
-    params.simulationSpeed = prevSimSpeed;
-    params.foamEnabled = preserveFoam;
-    if (preserveRings && prevRingSettings) {
-      Object.assign(params, prevRingSettings);
-    }
-  
-    params.seed = newSeed;
-  
-    if (isGasGiant) {
-      params.radius = THREE.MathUtils.lerp(2.0, 4.0, rng.next());
-      params.gasGiantStrataCount = Math.round(THREE.MathUtils.lerp(2, 6, rng.next()));
-      let totalSize = 0;
-      for (let i = 1; i <= params.gasGiantStrataCount; i++) {
-        const hue = rng.next();
-        params[`gasGiantStrataColor${i}`] = `#${new THREE.Color().setHSL(hue, rng.next() * 0.4 + 0.3, rng.next() * 0.4 + 0.3).getHexString()}`;
-        const size = rng.next();
-        params[`gasGiantStrataSize${i}`] = size;
-        totalSize += size;
-      }
-      if (totalSize > 0) {
-        for (let i = 1; i <= params.gasGiantStrataCount; i++) {
-          params[`gasGiantStrataSize${i}`] /= totalSize;
+function createRandomPlanetConfiguration(options = {}) {
+  const {
+    baseParams = params,
+    allowRingRandomization = true,
+    includeStar = false,
+  } = options;
+
+  const nextParams = clone(baseParams) || {};
+  if (!Array.isArray(nextParams.rings)) nextParams.rings = [];
+  if (!nextParams.aurora) {
+    nextParams.aurora = {
+      enabled: false,
+      colors: ["#38ff7a", "#3fb4ff"],
+      latitudeCenterDeg: 60,
+      latitudeWidthDeg: 10,
+      height: 0.06,
+      intensity: 1,
+      noiseScale: 2,
+      banding: 0.5,
+      nightBoost: 1.5,
+    };
+  } else if (!Array.isArray(nextParams.aurora.colors)) {
+    nextParams.aurora.colors = ["#38ff7a", "#3fb4ff"];
+  } else {
+    nextParams.aurora.colors = [...nextParams.aurora.colors];
+  }
+
+  nextParams.rings = Array.isArray(baseParams.rings)
+    ? baseParams.rings.map((ring) => ({ ...ring }))
+    : [];
+
+  const newSeed = generateSeed();
+  const rng = new SeededRNG(newSeed);
+  const isGasGiant = rng.next() < 1 / 6;
+
+  nextParams.planetType = isGasGiant ? "gas_giant" : "rocky";
+
+  const presetCandidates = Object.keys(presets).filter((key) => {
+    const preset = presets[key];
+    if (!preset) return false;
+    if (isGasGiant) return preset.planetType === "gas_giant";
+    return preset.planetType === "rocky" || !preset.planetType;
+  });
+  if (presetCandidates.length) {
+    const presetName = presetCandidates[Math.floor(rng.next() * presetCandidates.length)];
+    const preset = presets[presetName];
+    if (preset) {
+      const { moons: _presetMoons, aurora: presetAurora, ...rest } = preset;
+      Object.keys(rest).forEach((key) => {
+        nextParams[key] = clone(rest[key]);
+      });
+      if (presetAurora) {
+        nextParams.aurora = clone(presetAurora) || nextParams.aurora;
+        if (!Array.isArray(nextParams.aurora.colors)) {
+          nextParams.aurora.colors = ["#38ff7a", "#3fb4ff"];
         }
       }
-      params.gasGiantNoiseScale = THREE.MathUtils.lerp(1.0, 8.0, rng.next());
-      params.gasGiantNoiseStrength = THREE.MathUtils.lerp(0.05, 0.3, rng.next());
-      params.gasGiantStrataWarp = THREE.MathUtils.lerp(0.01, 0.1, rng.next());
-      params.gasGiantStrataWarpScale = THREE.MathUtils.lerp(2.0, 12.0, rng.next());
-    } else {
-      params.radius = THREE.MathUtils.lerp(0.6, 2.0, rng.next());
-      params.subdivisions = Math.round(THREE.MathUtils.lerp(4, 6, rng.next()));
-      params.noiseLayers = Math.round(THREE.MathUtils.lerp(3, 7, rng.next()));
-      params.noiseFrequency = THREE.MathUtils.lerp(0.8, 5.2, rng.next());
-      params.noiseAmplitude = THREE.MathUtils.lerp(0.2, 0.9, rng.next());
-      params.persistence = THREE.MathUtils.lerp(0.35, 0.65, rng.next());
-      params.lacunarity = THREE.MathUtils.lerp(1.6, 3.2, rng.next());
-      params.oceanLevel = THREE.MathUtils.lerp(0.0, 0.75, rng.next() * rng.next());
-      const hue = rng.next();
-      const hue2 = (hue + 0.12 + rng.next() * 0.2) % 1;
-      const hue3 = (hue + 0.3 + rng.next() * 0.3) % 1;
-      params.colorOcean = `#${new THREE.Color().setHSL(hue, 0.6, 0.28).getHexString()}`;
-      params.colorShallow = `#${new THREE.Color().setHSL(hue, 0.55, 0.45).getHexString()}`;
-      params.colorLow = `#${new THREE.Color().setHSL(hue2, 0.42, 0.3).getHexString()}`;
-      params.colorMid = `#${new THREE.Color().setHSL(hue2, 0.36, 0.58).getHexString()}`;
-      params.colorHigh = `#${new THREE.Color().setHSL(hue3, 0.15, 0.92).getHexString()}`;
-      params.colorCore = `#${new THREE.Color().setHSL(hue, 0.4, 0.3).getHexString()}`;
-      params.coreEnabled = true;
-      params.coreSize = THREE.MathUtils.lerp(0.2, 0.6, rng.next());
-      params.coreVisible = true;
-      params.icePolesEnabled = rng.next() < 0.7;
-      params.icePolesCoverage = THREE.MathUtils.lerp(0.05, 0.3, rng.next());
-      params.icePolesColor = `#${new THREE.Color().setHSL(0.6, rng.next() * 0.2 + 0.1, rng.next() * 0.3 + 0.7).getHexString()}`;
-      params.icePolesNoiseScale = THREE.MathUtils.lerp(1.0, 4.0, rng.next());
-      params.icePolesNoiseStrength = THREE.MathUtils.lerp(0.1, 0.5, rng.next());
+      nextParams.preset = presetName;
     }
-  
-    params.axisTilt = THREE.MathUtils.lerp(0, 45, rng.next());
-    params.rotationSpeed = THREE.MathUtils.lerp(0.05, 0.5, rng.next());
-    params.gravity = THREE.MathUtils.lerp(4, 25, rng.next());
-    const atmHue = rng.next();
-    params.atmosphereColor = `#${new THREE.Color().setHSL(atmHue, 0.6, 0.55).getHexString()}`;
-    params.atmosphereOpacity = THREE.MathUtils.lerp(0.05, 0.5, rng.next());
-    params.cloudsOpacity = THREE.MathUtils.lerp(0.1, 0.8, rng.next());
-    params.cloudHeight = THREE.MathUtils.lerp(0.01, 0.12, rng.next());
-    params.cloudDensity = THREE.MathUtils.lerp(0.25, 0.85, rng.next());
-    params.cloudNoiseScale = THREE.MathUtils.lerp(1.2, 5.0, rng.next());
-    params.cloudDriftSpeed = THREE.MathUtils.lerp(0, 0.06, rng.next());
-  
+  } else {
+    nextParams.preset = null;
+  }
+
+  nextParams.seed = newSeed;
+
+  if (isGasGiant) {
+    nextParams.radius = THREE.MathUtils.lerp(2.0, 4.0, rng.next());
+    nextParams.gasGiantStrataCount = Math.round(THREE.MathUtils.lerp(2, 6, rng.next()));
+    let totalSize = 0;
+    for (let i = 1; i <= nextParams.gasGiantStrataCount; i += 1) {
+      const hue = rng.next();
+      nextParams[`gasGiantStrataColor${i}`] = `#${new THREE.Color().setHSL(hue, rng.next() * 0.4 + 0.3, rng.next() * 0.4 + 0.3).getHexString()}`;
+      const size = rng.next();
+      nextParams[`gasGiantStrataSize${i}`] = size;
+      totalSize += size;
+    }
+    if (totalSize > 0) {
+      for (let i = 1; i <= nextParams.gasGiantStrataCount; i += 1) {
+        nextParams[`gasGiantStrataSize${i}`] /= totalSize;
+      }
+    }
+    nextParams.gasGiantNoiseScale = THREE.MathUtils.lerp(1.0, 8.0, rng.next());
+    nextParams.gasGiantNoiseStrength = THREE.MathUtils.lerp(0.05, 0.3, rng.next());
+    nextParams.gasGiantStrataWarp = THREE.MathUtils.lerp(0.01, 0.1, rng.next());
+    nextParams.gasGiantStrataWarpScale = THREE.MathUtils.lerp(2.0, 12.0, rng.next());
+  } else {
+    nextParams.radius = THREE.MathUtils.lerp(0.6, 2.0, rng.next());
+    nextParams.subdivisions = Math.round(THREE.MathUtils.lerp(4, 6, rng.next()));
+    nextParams.noiseLayers = Math.round(THREE.MathUtils.lerp(3, 7, rng.next()));
+    nextParams.noiseFrequency = THREE.MathUtils.lerp(0.8, 5.2, rng.next());
+    nextParams.noiseAmplitude = THREE.MathUtils.lerp(0.2, 0.9, rng.next());
+    nextParams.persistence = THREE.MathUtils.lerp(0.35, 0.65, rng.next());
+    nextParams.lacunarity = THREE.MathUtils.lerp(1.6, 3.2, rng.next());
+    nextParams.oceanLevel = THREE.MathUtils.lerp(0.0, 0.75, rng.next() * rng.next());
+    const hue = rng.next();
+    const hue2 = (hue + 0.12 + rng.next() * 0.2) % 1;
+    const hue3 = (hue + 0.3 + rng.next() * 0.3) % 1;
+    nextParams.colorOcean = `#${new THREE.Color().setHSL(hue, 0.6, 0.28).getHexString()}`;
+    nextParams.colorShallow = `#${new THREE.Color().setHSL(hue, 0.55, 0.45).getHexString()}`;
+    nextParams.colorLow = `#${new THREE.Color().setHSL(hue2, 0.42, 0.3).getHexString()}`;
+    nextParams.colorMid = `#${new THREE.Color().setHSL(hue2, 0.36, 0.58).getHexString()}`;
+    nextParams.colorHigh = `#${new THREE.Color().setHSL(hue3, 0.15, 0.92).getHexString()}`;
+    nextParams.colorCore = `#${new THREE.Color().setHSL(hue, 0.4, 0.3).getHexString()}`;
+    nextParams.coreEnabled = true;
+    nextParams.coreSize = THREE.MathUtils.lerp(0.2, 0.6, rng.next());
+    nextParams.coreVisible = true;
+    nextParams.icePolesEnabled = rng.next() < 0.7;
+    nextParams.icePolesCoverage = THREE.MathUtils.lerp(0.05, 0.3, rng.next());
+    nextParams.icePolesColor = `#${new THREE.Color().setHSL(0.6, rng.next() * 0.2 + 0.1, rng.next() * 0.3 + 0.7).getHexString()}`;
+    nextParams.icePolesNoiseScale = THREE.MathUtils.lerp(1.0, 4.0, rng.next());
+    nextParams.icePolesNoiseStrength = THREE.MathUtils.lerp(0.1, 0.5, rng.next());
+  }
+
+  nextParams.axisTilt = THREE.MathUtils.lerp(0, 45, rng.next());
+  nextParams.rotationSpeed = THREE.MathUtils.lerp(0.05, 0.5, rng.next());
+  nextParams.gravity = THREE.MathUtils.lerp(4, 25, rng.next());
+  const atmHue = rng.next();
+  nextParams.atmosphereColor = `#${new THREE.Color().setHSL(atmHue, 0.6, 0.55).getHexString()}`;
+  nextParams.atmosphereOpacity = THREE.MathUtils.lerp(0.05, 0.5, rng.next());
+  nextParams.cloudsOpacity = THREE.MathUtils.lerp(0.1, 0.8, rng.next());
+  nextParams.cloudHeight = THREE.MathUtils.lerp(0.01, 0.12, rng.next());
+  nextParams.cloudDensity = THREE.MathUtils.lerp(0.25, 0.85, rng.next());
+  nextParams.cloudNoiseScale = THREE.MathUtils.lerp(1.2, 5.0, rng.next());
+  nextParams.cloudDriftSpeed = THREE.MathUtils.lerp(0, 0.06, rng.next());
+
+  let starConfig = null;
+  if (includeStar) {
     if (rng.next() > 0.2) {
-      params.sunVariant = "Star";
       const starPresetNames = Object.keys(starPresets);
       const pickedStarPreset = starPresetNames[Math.floor(rng.next() * starPresetNames.length)];
-      applyStarPreset(pickedStarPreset, { skipShareUpdate: true });
+      starConfig = { type: "preset", preset: pickedStarPreset };
     } else {
-      params.sunVariant = "Black Hole";
-      params.blackHoleCoreSize = THREE.MathUtils.lerp(0.4, 1.6, rng.next());
-      params.blackHoleDiskRadius = params.blackHoleCoreSize * THREE.MathUtils.lerp(1.8, 4.0, rng.next());
-      params.blackHoleDiskThickness = THREE.MathUtils.lerp(0.1, 0.8, rng.next());
-      params.blackHoleDiskIntensity = THREE.MathUtils.lerp(0.8, 2.5, rng.next());
-      params.blackHoleHaloRadius = params.blackHoleDiskRadius * THREE.MathUtils.lerp(1.1, 1.8, rng.next());
-      params.blackHoleHaloAngle = THREE.MathUtils.lerp(20, 160, rng.next());
+      const blackHoleCoreSize = THREE.MathUtils.lerp(0.4, 1.6, rng.next());
+      const diskRadius = blackHoleCoreSize * THREE.MathUtils.lerp(1.8, 4.0, rng.next());
+      const haloRadius = diskRadius * THREE.MathUtils.lerp(1.1, 1.8, rng.next());
+      starConfig = {
+        type: "blackHole",
+        values: {
+          blackHoleCoreSize,
+          blackHoleDiskRadius: diskRadius,
+          blackHoleDiskThickness: THREE.MathUtils.lerp(0.1, 0.8, rng.next()),
+          blackHoleDiskIntensity: THREE.MathUtils.lerp(0.8, 2.5, rng.next()),
+          blackHoleHaloRadius: haloRadius,
+          blackHoleHaloAngle: THREE.MathUtils.lerp(20, 160, rng.next()),
+        },
+      };
     }
-  
-    params.moonCount = Math.round(THREE.MathUtils.lerp(0, 4, rng.next() * rng.next()));
-    params.moonMassScale = THREE.MathUtils.lerp(0.6, 2.5, rng.next());
-    moonSettings.splice(0, moonSettings.length);
-    for (let i = 0; i < params.moonCount; i += 1) {
-      moonSettings.push({
-        size: THREE.MathUtils.lerp(0.08, 0.4, rng.next()),
-        distance: THREE.MathUtils.lerp(2.4, 12.5, rng.next()),
-        orbitSpeed: THREE.MathUtils.lerp(0.4, 1.2, rng.next()),
-        inclination: THREE.MathUtils.lerp(-25, 25, rng.next()),
-        color: `#${new THREE.Color().setHSL((rng.next() + 0.5) % 1, 0.15 + rng.next() * 0.3, 0.6 + rng.next() * 0.2).getHexString()}`,
-        phase: rng.next() * Math.PI * 2,
-        eccentricity: THREE.MathUtils.lerp(0.02, 0.55, rng.next())
-      });
-    }
-  
-    if (!preserveRings) {
-      params.ringEnabled = rng.next() > 0.5;
-      if (params.ringEnabled) {
-        params.ringCount = Math.round(THREE.MathUtils.lerp(1, 5, rng.next()));
-        params.ringAngle = THREE.MathUtils.lerp(-45, 45, rng.next());
-        params.rings.splice(0, params.rings.length);
-        let lastRadius = 1.2;
-        for (let i = 0; i < params.ringCount; i += 1) {
-          const start = lastRadius + THREE.MathUtils.lerp(0.05, 0.2, rng.next());
-          const end = start + THREE.MathUtils.lerp(0.1, 0.5, rng.next());
-          params.rings.push({
-            style: rng.next() > 0.5 ? "Texture" : "Noise",
-            color: `#${new THREE.Color().setHSL(rng.next(), 0.15, 0.6).getHexString()}`,
-            start, end, opacity: THREE.MathUtils.lerp(0.4, 0.9, rng.next()),
-            noiseScale: THREE.MathUtils.lerp(1.5, 6.0, rng.next()),
-            noiseStrength: THREE.MathUtils.lerp(0.1, 0.6, rng.next()),
-            spinSpeed: THREE.MathUtils.lerp(-0.1, 0.1, rng.next()),
-            brightness: 1
-          });
-          lastRadius = end;
-        }
+  }
+
+  const moonCount = Math.round(THREE.MathUtils.lerp(0, 4, rng.next() * rng.next()));
+  const moonMassScale = THREE.MathUtils.lerp(0.6, 2.5, rng.next());
+  const moonSettingsOut = [];
+  for (let i = 0; i < moonCount; i += 1) {
+    moonSettingsOut.push({
+      size: THREE.MathUtils.lerp(0.08, 0.4, rng.next()),
+      distance: THREE.MathUtils.lerp(2.4, 12.5, rng.next()),
+      orbitSpeed: THREE.MathUtils.lerp(0.4, 1.2, rng.next()),
+      inclination: THREE.MathUtils.lerp(-25, 25, rng.next()),
+      color: `#${new THREE.Color().setHSL((rng.next() + 0.5) % 1, 0.15 + rng.next() * 0.3, 0.6 + rng.next() * 0.2).getHexString()}`,
+      phase: rng.next() * Math.PI * 2,
+      eccentricity: THREE.MathUtils.lerp(0.02, 0.55, rng.next()),
+    });
+  }
+
+  nextParams.moonCount = moonCount;
+  nextParams.moonMassScale = moonMassScale;
+
+  if (allowRingRandomization) {
+    nextParams.ringEnabled = rng.next() > 0.5;
+    nextParams.rings = [];
+    if (nextParams.ringEnabled) {
+      nextParams.ringCount = Math.round(THREE.MathUtils.lerp(1, 5, rng.next()));
+      nextParams.ringAngle = THREE.MathUtils.lerp(-45, 45, rng.next());
+      let lastRadius = 1.2;
+      for (let i = 0; i < nextParams.ringCount; i += 1) {
+        const start = lastRadius + THREE.MathUtils.lerp(0.05, 0.2, rng.next());
+        const end = start + THREE.MathUtils.lerp(0.1, 0.5, rng.next());
+        nextParams.rings.push({
+          style: rng.next() > 0.5 ? "Texture" : "Noise",
+          color: `#${new THREE.Color().setHSL(rng.next(), 0.15, 0.6).getHexString()}`,
+          start,
+          end,
+          opacity: THREE.MathUtils.lerp(0.4, 0.9, rng.next()),
+          noiseScale: THREE.MathUtils.lerp(1.5, 6.0, rng.next()),
+          noiseStrength: THREE.MathUtils.lerp(0.1, 0.6, rng.next()),
+          spinSpeed: THREE.MathUtils.lerp(-0.1, 0.1, rng.next()),
+          brightness: 1,
+        });
+        lastRadius = end;
       }
+    } else {
+      nextParams.ringCount = 0;
     }
+  } else {
+    nextParams.ringEnabled = baseParams.ringEnabled;
+    nextParams.ringAngle = baseParams.ringAngle;
+    nextParams.ringCount = baseParams.ringCount ?? nextParams.rings.length;
+    nextParams.ringSpinSpeed = baseParams.ringSpinSpeed;
+    nextParams.rings = Array.isArray(baseParams.rings)
+      ? baseParams.rings.map((ring) => ({ ...ring }))
+      : [];
+  }
 
-    // Randomize aurora
-    params.aurora.enabled = rng.next() > 0.3; // 70% chance of aurora
-    if (params.aurora.enabled) {
-      const h1 = rng.next();
-      const h2 = (h1 + 0.4 + rng.next() * 0.2) % 1.0;
-      // mutate colors to preserve array identity
-      params.aurora.colors[0] = `#${new THREE.Color().setHSL(h1, 0.9, 0.6).getHexString()}`;
-      params.aurora.colors[1] = `#${new THREE.Color().setHSL(h2, 0.9, 0.6).getHexString()}`;
-      params.aurora.latitudeCenterDeg = 60 + rng.next() * 15;
-      params.aurora.latitudeWidthDeg = THREE.MathUtils.lerp(8, 20, rng.next());
-      // Aurora height at atmosphere level (matches Earth-like preset)
-      params.aurora.height = 0.06;
-      params.aurora.intensity = THREE.MathUtils.lerp(0.5, 2.0, rng.next());
-      params.aurora.noiseScale = THREE.MathUtils.lerp(1.0, 5.0, rng.next());
-      params.aurora.banding = THREE.MathUtils.lerp(0.3, 1.0, rng.next());
-      params.aurora.nightBoost = THREE.MathUtils.lerp(1.2, 2.5, rng.next());
+  nextParams.aurora.enabled = rng.next() > 0.3;
+  if (nextParams.aurora.enabled) {
+    const h1 = rng.next();
+    const h2 = (h1 + 0.4 + rng.next() * 0.2) % 1.0;
+    nextParams.aurora.colors[0] = `#${new THREE.Color().setHSL(h1, 0.9, 0.6).getHexString()}`;
+    nextParams.aurora.colors[1] = `#${new THREE.Color().setHSL(h2, 0.9, 0.6).getHexString()}`;
+    nextParams.aurora.latitudeCenterDeg = 60 + rng.next() * 15;
+    nextParams.aurora.latitudeWidthDeg = THREE.MathUtils.lerp(8, 20, rng.next());
+    nextParams.aurora.height = 0.06;
+    nextParams.aurora.intensity = THREE.MathUtils.lerp(0.5, 2.0, rng.next());
+    nextParams.aurora.noiseScale = THREE.MathUtils.lerp(1.0, 5.0, rng.next());
+    nextParams.aurora.banding = THREE.MathUtils.lerp(0.3, 1.0, rng.next());
+    nextParams.aurora.nightBoost = THREE.MathUtils.lerp(1.2, 2.5, rng.next());
+  }
+
+  return { params: nextParams, moonSettings: moonSettingsOut, starConfig };
+}
+
+function surpriseMe(targetPlanetId = null) {
+  const currentId = targetPlanetId ?? planetSystem?.getCurrentPlanetId?.() ?? "primary";
+
+  if (planetSystem && currentId && currentId !== "primary") {
+    const config = createRandomPlanetConfiguration({ allowRingRandomization: true });
+    planetSystem.applyPlanetState(currentId, config.params, config.moonSettings, {
+      radius: config.params.radius,
+      spinSpeed: config.params.rotationSpeed,
+      seed: config.params.seed,
+      preset: config.params.preset ?? null,
+      type: config.params.planetType ?? config.params.type,
+    });
+    planetSystem.focusPlanet(currentId);
+    systemPanel?.setSelected?.(currentId);
+    scheduleShareUpdate();
+    return;
+  }
+
+  const prevSimSpeed = params.simulationSpeed;
+  const preserveFoam = params.foamEnabled;
+  const preserveRings = !params.ringAllowRandom;
+  const prevRingSettings = preserveRings
+    ? {
+        ringEnabled: params.ringEnabled,
+        ringAngle: params.ringAngle,
+        ringSpinSpeed: params.ringSpinSpeed,
+        ringCount: params.ringCount,
+        rings: params.rings.map((ring) => ({ ...ring })),
+      }
+    : null;
+
+  const config = createRandomPlanetConfiguration({ allowRingRandomization: !preserveRings, includeStar: true });
+  const randomParams = config.params;
+  const randomMoons = config.moonSettings;
+
+  const shallowCopy = clone(randomParams) || {};
+  const auroraParams = shallowCopy.aurora;
+  const ringParams = Array.isArray(shallowCopy.rings) ? shallowCopy.rings : [];
+  delete shallowCopy.aurora;
+  delete shallowCopy.rings;
+
+  Object.assign(params, shallowCopy);
+
+  params.simulationSpeed = prevSimSpeed;
+  params.foamEnabled = preserveFoam;
+
+  if (auroraParams) {
+    if (!params.aurora) params.aurora = { colors: ["#38ff7a", "#3fb4ff"] };
+    params.aurora.enabled = auroraParams.enabled;
+    params.aurora.latitudeCenterDeg = auroraParams.latitudeCenterDeg;
+    params.aurora.latitudeWidthDeg = auroraParams.latitudeWidthDeg;
+    params.aurora.height = auroraParams.height;
+    params.aurora.intensity = auroraParams.intensity;
+    params.aurora.noiseScale = auroraParams.noiseScale;
+    params.aurora.banding = auroraParams.banding;
+    params.aurora.nightBoost = auroraParams.nightBoost;
+    if (!Array.isArray(params.aurora.colors)) params.aurora.colors = ["#38ff7a", "#3fb4ff"];
+    if (Array.isArray(auroraParams.colors)) {
+      params.aurora.colors[0] = auroraParams.colors[0];
+      params.aurora.colors[1] = auroraParams.colors[1];
     }
+  }
 
-    Object.keys(guiControllers).forEach((key) => {
-      if (params[key] !== undefined && guiControllers[key]?.setValue) {
-        isApplyingPreset = true;
-        guiControllers[key].setValue(params[key]);
+  if (!preserveRings) {
+    params.rings.splice(0, params.rings.length, ...ringParams.map((ring) => ({ ...ring })));
+    params.ringCount = randomParams.ringCount ?? params.rings.length;
+  } else if (prevRingSettings) {
+    params.ringEnabled = prevRingSettings.ringEnabled;
+    params.ringAngle = prevRingSettings.ringAngle;
+    params.ringSpinSpeed = prevRingSettings.ringSpinSpeed;
+    params.ringCount = prevRingSettings.ringCount;
+    params.rings.splice(0, params.rings.length, ...prevRingSettings.rings.map((ring) => ({ ...ring })));
+  }
+
+  moonSettings.splice(0, moonSettings.length, ...randomMoons.map((moon) => ({ ...moon })));
+  params.moonCount = randomParams.moonCount;
+  params.moonMassScale = randomParams.moonMassScale;
+
+  if (config.starConfig) {
+    if (config.starConfig.type === "preset") {
+      params.sunVariant = "Star";
+      applyStarPreset(config.starConfig.preset, { skipShareUpdate: true });
+    } else if (config.starConfig.type === "blackHole") {
+      params.sunVariant = "Black Hole";
+      const starValues = config.starConfig.values;
+      params.blackHoleCoreSize = starValues.blackHoleCoreSize;
+      params.blackHoleDiskRadius = starValues.blackHoleDiskRadius;
+      params.blackHoleDiskThickness = starValues.blackHoleDiskThickness;
+      params.blackHoleDiskIntensity = starValues.blackHoleDiskIntensity;
+      params.blackHoleHaloRadius = starValues.blackHoleHaloRadius;
+      params.blackHoleHaloAngle = starValues.blackHoleHaloAngle;
+    }
+  }
+
+  planetSystem?.updatePrimarySnapshot(clone(params), moonSettings.slice(0, params.moonCount));
+  systemPanel?.setSelected?.("primary");
+
+  Object.keys(guiControllers).forEach((key) => {
+    if (params[key] !== undefined && guiControllers[key]?.setValue) {
+      isApplyingPreset = true;
+      guiControllers[key].setValue(params[key]);
+      isApplyingPreset = false;
+    }
+  });
+
+  try {
+    Object.values(guiControllers).forEach((ctrl) => ctrl?.updateDisplay?.());
+    guiControllers.refreshPlanetTypeVisibility(params.planetType);
+    guiControllers.rebuildRingControls?.();
+
+    if (params.aurora) {
+      isApplyingPreset = true;
+      try {
+        if (guiControllers.auroraEnabled) guiControllers.auroraEnabled.setValue(params.aurora.enabled);
+        if (guiControllers.auroraColor1) guiControllers.auroraColor1.setValue(params.aurora.colors[0]);
+        if (guiControllers.auroraColor2) guiControllers.auroraColor2.setValue(params.aurora.colors[1]);
+        if (guiControllers.auroraLatitudeCenter) guiControllers.auroraLatitudeCenter.setValue(params.aurora.latitudeCenterDeg);
+        if (guiControllers.auroraLatitudeWidth) guiControllers.auroraLatitudeWidth.setValue(params.aurora.latitudeWidthDeg);
+        if (guiControllers.auroraIntensity) guiControllers.auroraIntensity.setValue(params.aurora.intensity);
+        if (guiControllers.auroraNoiseScale) guiControllers.auroraNoiseScale.setValue(params.aurora.noiseScale);
+        if (guiControllers.auroraBanding) guiControllers.auroraBanding.setValue(params.aurora.banding);
+        if (guiControllers.auroraNightBoost) guiControllers.auroraNightBoost.setValue(params.aurora.nightBoost);
+      } finally {
         isApplyingPreset = false;
       }
-    });
+    }
+  } catch {}
 
-    try {
-      Object.values(guiControllers).forEach((ctrl) => ctrl?.updateDisplay?.());
-      guiControllers.refreshPlanetTypeVisibility(params.planetType);
-      guiControllers.rebuildRingControls?.();
-      
-      // Update aurora controllers explicitly using setValue for proper GUI updates
-      if (params.aurora) {
-        isApplyingPreset = true;
-        try {
-          if (guiControllers.auroraEnabled) guiControllers.auroraEnabled.setValue(params.aurora.enabled);
-          if (guiControllers.auroraColor1) guiControllers.auroraColor1.setValue(params.aurora.colors[0]);
-          if (guiControllers.auroraColor2) guiControllers.auroraColor2.setValue(params.aurora.colors[1]);
-          if (guiControllers.auroraLatitudeCenter) guiControllers.auroraLatitudeCenter.setValue(params.aurora.latitudeCenterDeg);
-          if (guiControllers.auroraLatitudeWidth) guiControllers.auroraLatitudeWidth.setValue(params.aurora.latitudeWidthDeg);
-          // Aurora height is fixed - no controller to update
-          if (guiControllers.auroraIntensity) guiControllers.auroraIntensity.setValue(params.aurora.intensity);
-          if (guiControllers.auroraNoiseScale) guiControllers.auroraNoiseScale.setValue(params.aurora.noiseScale);
-          if (guiControllers.auroraBanding) guiControllers.auroraBanding.setValue(params.aurora.banding);
-          if (guiControllers.auroraNightBoost) guiControllers.auroraNightBoost.setValue(params.aurora.nightBoost);
-        } finally {
-          isApplyingPreset = false;
-        }
-      }
-    } catch {}
+  normalizeMoonSettings();
+  handleSeedChanged({ skipShareUpdate: true });
+  planet.updatePalette();
+  planet.updateClouds();
+  sun.updateSun();
+  planet.updateRings();
+  planet.updateTilt();
+  updateGravityDisplay();
+  rebuildMoonControls();
+  markMoonsDirty();
+  planet.initMoonPhysics();
+  updateStarfieldUniforms();
+  planet.guiControllers.updateStabilityDisplay(moonSettings.length, moonSettings.length);
+  scheduleShareUpdate();
 
-    normalizeMoonSettings();
-    handleSeedChanged({ skipShareUpdate: true });
-    planet.updatePalette();
-    planet.updateClouds();
-    sun.updateSun();
-    planet.updateRings();
-    planet.updateTilt();
-    updateGravityDisplay();
-    rebuildMoonControls();
-    markMoonsDirty();
-    planet.initMoonPhysics();
-    updateStarfieldUniforms();
-    planet.guiControllers.updateStabilityDisplay(moonSettings.length, moonSettings.length);
-    scheduleShareUpdate();
-    
-    // Force immediate URL update for surprise me to prevent loss on reload
-    setTimeout(() => {
-      if (shareDirty) {
-        updateShareCode();
-        shareDirty = false;
-      }
-    }, 200); // Slightly longer than debounce to ensure it runs after
+  setTimeout(() => {
+    if (shareDirty) {
+      updateShareCode();
+      shareDirty = false;
+    }
+  }, 200);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1393,9 +1393,93 @@ body.photo-mode #scene {
     flex-direction: column;
   }
 
-  .visual-settings-reset,
+.visual-settings-reset,
   .visual-settings-apply {
     width: 100%;
   }
+}
+
+.system-panel-container {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.system-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.system-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.system-panel__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.system-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.system-panel__item {
+  background: rgba(9, 15, 26, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.system-panel__item--active {
+  border-color: rgba(120, 180, 255, 0.7);
+  box-shadow: 0 0 0 1px rgba(120, 180, 255, 0.35);
+}
+
+.system-panel__item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.system-panel__item-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.system-panel__item-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem;
+}
+
+.system-panel__slider {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.system-panel__slider input[type="range"] {
+  width: 100%;
+}
+
+.system-panel__value {
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.65);
 }
 

--- a/src/systems/PlanetSystem.ts
+++ b/src/systems/PlanetSystem.ts
@@ -1,0 +1,329 @@
+import * as THREE from "three";
+import { Planet } from "../app/planet.js";
+import { SeededRNG } from "../app/utils.js";
+
+export type PlanetOrbitParams = {
+  id: string;
+  seed: number;
+  preset: string | null;
+  radius: number;
+  semiMajorAxis: number;
+  orbitalSpeed: number;
+  phase: number;
+  inclination: number;
+  spinSpeed: number;
+  type?: string;
+};
+
+export type PlanetSystemEntry = {
+  id: string;
+  params: PlanetOrbitParams;
+  pivot: THREE.Object3D;
+  mesh: THREE.Object3D;
+  planet: Planet;
+  theta: number;
+  gizmo?: THREE.LineLoop;
+  moons: any[];
+  stateSnapshot: Record<string, any>;
+  isPrimary?: boolean;
+};
+
+type PlanetFactoryOptions = {
+  scene: THREE.Scene;
+  params: Record<string, any>;
+  moonSettings: any[];
+  guiControllers: Record<string, any>;
+  visualSettings: Record<string, any>;
+  sun: any;
+};
+
+type PlanetFactory = (options: PlanetFactoryOptions) => Planet;
+
+type FocusHandler = (object: THREE.Object3D | null, metadata?: { id?: string }) => void;
+
+type OrbitGizmoFactory = (radius: number) => THREE.LineLoop;
+
+function uuidv4() {
+  const rng = new SeededRNG(Math.random() * 1e9);
+  const segments: string[] = [];
+  for (let i = 0; i < 4; i++) {
+    segments.push(Math.floor(rng.random() * 0xffffffff).toString(16).padStart(8, "0"));
+  }
+  return `${segments[0]}-${segments[1].slice(0, 4)}-${segments[2].slice(0, 4)}-${segments[3].slice(0, 4)}-${segments[1].slice(4)}${segments[2].slice(4)}${segments[3].slice(4)}`;
+}
+
+export class PlanetSystem {
+  scene: THREE.Scene;
+  sun: any;
+  starAnchor: THREE.Object3D;
+  planets: Map<string, PlanetSystemEntry> = new Map();
+  order: string[] = [];
+  factory: PlanetFactory;
+  focusHandler?: FocusHandler;
+  orbitFactory: OrbitGizmoFactory;
+  timeScale = 1;
+  viewMode: "close" | "system" = "close";
+  orbitGizmosVisible = true;
+  controls?: any;
+  systemCameraState: { position: THREE.Vector3; target: THREE.Vector3 } | null = null;
+
+  constructor(
+    scene: THREE.Scene,
+    sun: any,
+    factory: PlanetFactory,
+    orbitFactory: OrbitGizmoFactory,
+    focusHandler?: FocusHandler,
+  ) {
+    this.scene = scene;
+    this.sun = sun;
+    this.factory = factory;
+    this.focusHandler = focusHandler;
+    this.orbitFactory = orbitFactory;
+
+    this.starAnchor = new THREE.Group();
+    this.starAnchor.name = "StarAnchor";
+    this.scene.add(this.starAnchor);
+
+    if (this.sun?.sunGroup && this.sun.sunGroup.parent !== this.starAnchor) {
+      this.scene.remove(this.sun.sunGroup);
+      this.starAnchor.add(this.sun.sunGroup);
+    }
+  }
+
+  attachControls(controls: any) {
+    this.controls = controls;
+  }
+
+  createFromExisting(id: string, planet: Planet, stateSnapshot: Record<string, any>, params: Partial<PlanetOrbitParams> = {}) {
+    const entryId = id || uuidv4();
+    const pivot = new THREE.Object3D();
+    pivot.name = `PlanetPivot_${entryId}`;
+    const mesh = (planet as any).planetSystem ?? planet.planetRoot ?? new THREE.Group();
+    if (mesh.parent) {
+      mesh.parent.remove(mesh);
+    }
+    const defaults: PlanetOrbitParams = {
+      id: entryId,
+      seed: planet.params?.seed || Math.floor(Math.random() * 1e9),
+      preset: planet.params?.preset ?? null,
+      radius: planet.params?.radius ?? 1,
+      semiMajorAxis: params.semiMajorAxis ?? 8,
+      orbitalSpeed: params.orbitalSpeed ?? 0.03,
+      phase: params.phase ?? 0,
+      inclination: params.inclination ?? THREE.MathUtils.degToRad(planet.params?.axisTilt ?? 0),
+      spinSpeed: params.spinSpeed ?? planet.params?.rotationSpeed ?? 0,
+      type: params.type ?? planet.params?.planetType ?? "rocky",
+    };
+
+    mesh.position.set(defaults.semiMajorAxis, 0, 0);
+    pivot.rotation.x = defaults.inclination;
+    pivot.add(mesh);
+
+    planet.params.rotationSpeed = defaults.spinSpeed;
+
+    const gizmo = this.orbitFactory(defaults.semiMajorAxis);
+    pivot.add(gizmo);
+    gizmo.visible = this.orbitGizmosVisible;
+
+    this.starAnchor.add(pivot);
+
+    const entry: PlanetSystemEntry = {
+      id: entryId,
+      params: defaults,
+      pivot,
+      mesh,
+      planet,
+      theta: defaults.phase,
+      gizmo,
+      moons: [],
+      stateSnapshot,
+      isPrimary: true,
+    };
+
+    this.planets.set(entryId, entry);
+    this.order.push(entryId);
+    return entry;
+  }
+
+  addPlanet(options: {
+    baseState: Record<string, any>;
+    moonSettings: any[];
+    guiControllers: Record<string, any>;
+    visualSettings: Record<string, any>;
+    orbitParams?: Partial<PlanetOrbitParams>;
+  }) {
+    const id = uuidv4();
+    const stateClone = structuredClone(options.baseState ?? {});
+    const pivot = new THREE.Object3D();
+    pivot.name = `PlanetPivot_${id}`;
+
+    const orbitParams: PlanetOrbitParams = {
+      id,
+      seed: options.orbitParams?.seed ?? Math.floor(Math.random() * 1e9),
+      preset: options.orbitParams?.preset ?? stateClone?.preset ?? null,
+      radius: options.orbitParams?.radius ?? stateClone?.radius ?? 1,
+      semiMajorAxis: options.orbitParams?.semiMajorAxis ?? 8 + this.planets.size * 4,
+      orbitalSpeed: options.orbitParams?.orbitalSpeed ?? 0.04,
+      phase: options.orbitParams?.phase ?? 0,
+      inclination: options.orbitParams?.inclination ?? 0,
+      spinSpeed: options.orbitParams?.spinSpeed ?? stateClone?.rotationSpeed ?? 0,
+      type: options.orbitParams?.type ?? stateClone?.planetType ?? "rocky",
+    };
+
+    const moonSettings = (options.moonSettings ?? []).map((m) => ({ ...m }));
+    const planetParams = { ...stateClone, seed: orbitParams.seed };
+
+    const planet = this.factory({
+      scene: this.scene,
+      params: planetParams,
+      moonSettings,
+      guiControllers: options.guiControllers,
+      visualSettings: options.visualSettings,
+      sun: this.sun,
+    });
+    planet.params.rotationSpeed = orbitParams.spinSpeed;
+
+    const mesh = (planet as any).planetSystem ?? planet.planetRoot ?? new THREE.Group();
+    if (mesh.parent) {
+      mesh.parent.remove(mesh);
+    }
+    mesh.position.set(orbitParams.semiMajorAxis, 0, 0);
+    pivot.rotation.x = orbitParams.inclination;
+    pivot.add(mesh);
+
+    const gizmo = this.orbitFactory(orbitParams.semiMajorAxis);
+    pivot.add(gizmo);
+    gizmo.visible = this.orbitGizmosVisible;
+
+    this.starAnchor.add(pivot);
+
+    const entry: PlanetSystemEntry = {
+      id,
+      params: orbitParams,
+      pivot,
+      mesh,
+      planet,
+      theta: orbitParams.phase,
+      gizmo,
+      moons: moonSettings,
+      stateSnapshot: planetParams,
+      isPrimary: false,
+    };
+
+    this.planets.set(id, entry);
+    this.order.push(id);
+
+    return id;
+  }
+
+  removePlanet(id: string) {
+    const entry = this.planets.get(id);
+    if (!entry || entry.isPrimary) return;
+    entry.pivot.parent?.remove(entry.pivot);
+    entry.planet?.dispose?.();
+    this.planets.delete(id);
+    this.order = this.order.filter((pid) => pid !== id);
+  }
+
+  duplicatePlanet(id: string) {
+    const entry = this.planets.get(id);
+    if (!entry) return null;
+    const cloneState = structuredClone(entry.stateSnapshot ?? {});
+    const newId = this.addPlanet({
+      baseState: cloneState,
+      moonSettings: entry.moons,
+      guiControllers: {},
+      visualSettings: {},
+      orbitParams: {
+        ...entry.params,
+        id: undefined,
+        phase: entry.params.phase + Math.PI / 4,
+      },
+    });
+    return newId;
+  }
+
+  regeneratePlanet(id: string, seed: number | null) {
+    const entry = this.planets.get(id);
+    if (!entry) return;
+    const newSeed = typeof seed === "number" ? seed : Math.floor(Math.random() * 1e9);
+    entry.params.seed = newSeed;
+    entry.stateSnapshot.seed = newSeed;
+    entry.planet.params.seed = newSeed;
+    entry.planet.rebuildPlanet?.();
+  }
+
+  updatePlanet(id: string, patch: Partial<PlanetOrbitParams>) {
+    const entry = this.planets.get(id);
+    if (!entry) return;
+    Object.assign(entry.params, patch);
+    const needsReposition = patch.semiMajorAxis !== undefined || patch.phase !== undefined;
+    if (patch.semiMajorAxis !== undefined && entry.gizmo) {
+      const gizmo = this.orbitFactory(entry.params.semiMajorAxis);
+      entry.pivot.remove(entry.gizmo);
+      entry.gizmo.geometry.dispose?.();
+      entry.gizmo.material.dispose?.();
+      entry.gizmo = gizmo;
+      entry.gizmo.visible = this.orbitGizmosVisible;
+      entry.pivot.add(entry.gizmo);
+    }
+    if (patch.inclination !== undefined) {
+      entry.pivot.rotation.x = patch.inclination;
+    }
+    if (patch.phase !== undefined) {
+      entry.theta = patch.phase;
+    }
+    if (patch.radius !== undefined) {
+      entry.planet.params.radius = entry.params.radius;
+      entry.planet.rebuildPlanet?.();
+    }
+    if (patch.spinSpeed !== undefined) {
+      entry.planet.params.rotationSpeed = entry.params.spinSpeed;
+    }
+    if (needsReposition) {
+      const a = entry.params.semiMajorAxis;
+      const x = a * Math.cos(entry.theta);
+      const z = a * Math.sin(entry.theta);
+      entry.mesh.position.set(x, 0, z);
+    }
+  }
+
+  getPlanets() {
+    return this.order.map((id) => this.planets.get(id)?.params).filter(Boolean) as PlanetOrbitParams[];
+  }
+
+  setTimeScale(scale: number) {
+    this.timeScale = scale;
+  }
+
+  setViewMode(mode: "close" | "system") {
+    this.viewMode = mode;
+  }
+
+  focusPlanet(id: string) {
+    const entry = this.planets.get(id);
+    if (!entry) return;
+    this.focusHandler?.(entry.mesh, { id });
+  }
+
+  toggleOrbitGizmos(visible: boolean) {
+    this.orbitGizmosVisible = visible;
+    this.planets.forEach((entry) => {
+      if (entry.gizmo) entry.gizmo.visible = visible;
+    });
+  }
+
+  update(delta: number, simulationDelta: number = delta) {
+    this.planets.forEach((entry) => {
+      entry.theta += entry.params.orbitalSpeed * simulationDelta * this.timeScale;
+      const a = entry.params.semiMajorAxis;
+      const x = a * Math.cos(entry.theta);
+      const z = a * Math.sin(entry.theta);
+      entry.mesh.position.set(x, 0, z);
+      if (!entry.isPrimary) {
+        entry.planet.params.rotationSpeed = entry.params.spinSpeed ?? entry.planet.params.rotationSpeed;
+        entry.planet.update(delta, simulationDelta, null);
+      }
+    });
+  }
+}

--- a/src/systems/SystemViewCamera.ts
+++ b/src/systems/SystemViewCamera.ts
@@ -6,7 +6,11 @@ export type SystemViewFrame = {
   distance: number;
 };
 
-export function computeSystemViewCamera(planets: { semiMajorAxis: number; radius: number }[], tilt = THREE.MathUtils.degToRad(30)) {
+export function computeSystemViewCamera(
+  planets: { semiMajorAxis: number; radius: number }[],
+  starPosition: THREE.Vector3,
+  tilt = THREE.MathUtils.degToRad(30),
+) {
   const maxExtent = planets.reduce((max, planet) => {
     const extent = (planet?.semiMajorAxis ?? 0) + (planet?.radius ?? 0);
     return Math.max(max, extent);
@@ -15,8 +19,9 @@ export function computeSystemViewCamera(planets: { semiMajorAxis: number; radius
   const height = Math.sin(tilt) * distance;
   const horizontal = Math.cos(tilt) * distance;
 
-  const position = new THREE.Vector3(horizontal, height, horizontal);
-  const target = new THREE.Vector3(0, 0, 0);
+  const offset = new THREE.Vector3(horizontal, height, horizontal);
+  const position = starPosition.clone().add(offset);
+  const target = starPosition.clone();
 
   return { position, target, distance } satisfies SystemViewFrame;
 }

--- a/src/systems/SystemViewCamera.ts
+++ b/src/systems/SystemViewCamera.ts
@@ -1,0 +1,36 @@
+import * as THREE from "three";
+
+export type SystemViewFrame = {
+  position: THREE.Vector3;
+  target: THREE.Vector3;
+  distance: number;
+};
+
+export function computeSystemViewCamera(planets: { semiMajorAxis: number; radius: number }[], tilt = THREE.MathUtils.degToRad(30)) {
+  const maxExtent = planets.reduce((max, planet) => {
+    const extent = (planet?.semiMajorAxis ?? 0) + (planet?.radius ?? 0);
+    return Math.max(max, extent);
+  }, 1);
+  const distance = Math.max(4, maxExtent * 2.4);
+  const height = Math.sin(tilt) * distance;
+  const horizontal = Math.cos(tilt) * distance;
+
+  const position = new THREE.Vector3(horizontal, height, horizontal);
+  const target = new THREE.Vector3(0, 0, 0);
+
+  return { position, target, distance } satisfies SystemViewFrame;
+}
+
+export function lerpCamera(
+  camera: THREE.PerspectiveCamera,
+  controls: { target: THREE.Vector3 } | null,
+  frame: SystemViewFrame,
+  alpha: number,
+) {
+  const nextPosition = camera.position.clone().lerp(frame.position, alpha);
+  camera.position.copy(nextPosition);
+  if (controls) {
+    controls.target.lerp(frame.target, alpha);
+  }
+  camera.lookAt(frame.target);
+}

--- a/src/ui/SystemPanel.html
+++ b/src/ui/SystemPanel.html
@@ -1,0 +1,13 @@
+<template id="system-panel-template">
+  <section class="system-panel">
+    <header class="system-panel__header">
+      <h2>System</h2>
+      <div class="system-panel__actions">
+        <button data-action="add">Add Planet</button>
+        <button data-action="toggle-view">System View</button>
+        <button data-action="toggle-gizmos" aria-pressed="true">Orbits On</button>
+      </div>
+    </header>
+    <div class="system-panel__list" role="list"></div>
+  </section>
+</template>

--- a/src/ui/SystemPanel.js
+++ b/src/ui/SystemPanel.js
@@ -1,0 +1,160 @@
+function createSlider(label, key, value, min, max, step) {
+  const wrapper = document.createElement("label");
+  wrapper.className = "system-panel__slider";
+
+  const span = document.createElement("span");
+  span.textContent = label;
+  wrapper.appendChild(span);
+
+  const input = document.createElement("input");
+  input.type = "range";
+  input.min = String(min);
+  input.max = String(max);
+  input.step = String(step);
+  input.value = String(value);
+  input.dataset.key = key;
+
+  const valueDisplay = document.createElement("span");
+  valueDisplay.className = "system-panel__value";
+  valueDisplay.textContent = value.toFixed(2);
+
+  input.addEventListener("input", () => {
+    valueDisplay.textContent = Number(input.value).toFixed(2);
+  });
+
+  wrapper.appendChild(input);
+  wrapper.appendChild(valueDisplay);
+
+  return { element: wrapper, input };
+}
+
+export class SystemPanel {
+  /** @param {HTMLElement} host */
+  constructor(host, systemApi) {
+    this.host = host;
+    this.systemApi = systemApi;
+    this.selectedId = null;
+
+    const tpl = document.getElementById("system-panel-template");
+    if (!tpl) {
+      console.warn("System panel template missing");
+      return;
+    }
+    const content = tpl.content.cloneNode(true);
+    this.root = content.querySelector(".system-panel");
+    this.list = content.querySelector(".system-panel__list");
+    this.toggleViewButton = content.querySelector("[data-action=toggle-view]");
+    this.toggleGizmoButton = content.querySelector("[data-action=toggle-gizmos]");
+
+    content.querySelector("[data-action=add]")?.addEventListener("click", () => {
+      const id = this.systemApi.addPlanet();
+      if (id) {
+        this.setSelected(id);
+      } else {
+        this.render();
+      }
+    });
+
+    this.toggleViewButton?.addEventListener("click", () => {
+      const next = this.systemApi.toggleViewMode();
+      this.toggleViewButton.textContent = next === "system" ? "Close View" : "System View";
+    });
+
+    this.toggleGizmoButton?.addEventListener("click", () => {
+      const pressed = this.toggleGizmoButton.getAttribute("aria-pressed") === "true";
+      const next = !pressed;
+      this.toggleGizmoButton.setAttribute("aria-pressed", String(next));
+      this.toggleGizmoButton.textContent = next ? "Orbits On" : "Orbits Off";
+      this.systemApi.toggleOrbitGizmos(next);
+    });
+
+    this.host.appendChild(content);
+    this.render();
+  }
+
+  setSelected(id) {
+    this.selectedId = id;
+    this.render();
+  }
+
+  render() {
+    if (!this.list) return;
+    this.list.innerHTML = "";
+    const planets = this.systemApi.getPlanets();
+    planets.forEach((planet) => {
+      const item = document.createElement("article");
+      item.className = "system-panel__item";
+      item.dataset.id = planet.id;
+      if (planet.id === this.selectedId) item.classList.add("system-panel__item--active");
+
+      const header = document.createElement("header");
+      header.className = "system-panel__item-header";
+      const title = document.createElement("h3");
+      title.textContent = planet.preset || `Planet ${planet.id.slice(0, 4)}`;
+      header.appendChild(title);
+
+      const actions = document.createElement("div");
+      actions.className = "system-panel__item-actions";
+      const focusBtn = document.createElement("button");
+      focusBtn.textContent = "Focus";
+      focusBtn.addEventListener("click", () => {
+        this.systemApi.focusPlanet(planet.id);
+        this.setSelected(planet.id);
+      });
+      const duplicateBtn = document.createElement("button");
+      duplicateBtn.textContent = "Duplicate";
+      duplicateBtn.addEventListener("click", () => {
+        const id = this.systemApi.duplicatePlanet(planet.id);
+        if (id) {
+          this.setSelected(id);
+        } else {
+          this.render();
+        }
+      });
+      const removeBtn = document.createElement("button");
+      removeBtn.textContent = "Delete";
+      removeBtn.addEventListener("click", () => {
+        this.systemApi.removePlanet(planet.id);
+        const remaining = this.systemApi.getPlanets();
+        this.selectedId = remaining[0]?.id ?? null;
+        this.render();
+      });
+      const regenBtn = document.createElement("button");
+      regenBtn.textContent = "Regenerate";
+      regenBtn.addEventListener("click", () => {
+        this.systemApi.regeneratePlanet(planet.id);
+      });
+      actions.append(focusBtn, duplicateBtn, regenBtn, removeBtn);
+      header.appendChild(actions);
+      item.appendChild(header);
+
+      const controls = document.createElement("div");
+      controls.className = "system-panel__item-controls";
+
+      const sliders = [
+        createSlider("Semi-major Axis", "semiMajorAxis", planet.semiMajorAxis, 0, 80, 0.5),
+        createSlider("Orbital Speed", "orbitalSpeed", planet.orbitalSpeed, 0, 1, 0.005),
+        createSlider("Inclination", "inclination", planet.inclination, -Math.PI / 2, Math.PI / 2, 0.01),
+        createSlider("Phase", "phase", planet.phase, 0, Math.PI * 2, 0.01),
+        createSlider("Spin", "spinSpeed", planet.spinSpeed, -2, 2, 0.01),
+        createSlider("Scale", "radius", planet.radius, 0.2, 5, 0.01),
+      ];
+
+      sliders.forEach(({ element, input }) => {
+        input.addEventListener("change", () => {
+          const key = input.dataset.key;
+          const value = Number(input.value);
+          this.systemApi.updatePlanet(planet.id, { [key]: value });
+        });
+        controls.appendChild(element);
+      });
+
+      item.appendChild(controls);
+      this.list.appendChild(item);
+    });
+  }
+}
+
+export function mountSystemPanel(host, systemApi) {
+  return new SystemPanel(host, systemApi);
+}


### PR DESCRIPTION
## Summary
- introduce a PlanetSystem orchestrator with circular orbit animation, orbit gizmos, and API hooks for creating, duplicating, updating, and removing planets
- add a system view camera helper plus a management panel UI so the user can toggle the system view, focus planets, and adjust orbital parameters
- update planet lighting calculations to use world positions and style the new system panel consistently with the studio UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d985e067a48324848cce159b4740fc